### PR TITLE
Extract Interface from MockContext and fix availability of some Context functions

### DIFF
--- a/.github/workflows/check_setup_py.yaml
+++ b/.github/workflows/check_setup_py.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6]
     runs-on: ubuntu-latest
 
     steps:

--- a/exasol_udf_mock_python/mock_context.py
+++ b/exasol_udf_mock_python/mock_context.py
@@ -1,4 +1,3 @@
-import itertools
 from typing import List, Tuple, Iterator
 
 import pandas as pd
@@ -6,9 +5,10 @@ import pandas as pd
 from exasol_udf_mock_python.column import Column
 from exasol_udf_mock_python.group import Group
 from exasol_udf_mock_python.mock_meta_data import MockMetaData
+from exasol_udf_mock_python.udf_context import UDFContext
 
 
-class MockContext:
+class MockContext(UDFContext):
 
     def __init__(self, input_groups: Iterator[Group], metadata: MockMetaData):
         self._input_groups = input_groups
@@ -81,7 +81,7 @@ class MockContext:
             try:
                 new_data = next(self._iter)
                 self._data = new_data
-                self.validate_tuples(self._data, self._metadata.input_columns)
+                self._validate_tuples(self._data, self._metadata.input_columns)
                 return True
             except StopIteration as e:
                 self._data = None
@@ -100,11 +100,11 @@ class MockContext:
         else:
             tuples = [args]
         for row in tuples:
-            self.validate_tuples(row, self._metadata.output_columns)
+            self._validate_tuples(row, self._metadata.output_columns)
         self._output_group_list.extend(tuples)
         return
 
-    def validate_tuples(self, row: Tuple, columns: List[Column]):
+    def _validate_tuples(self, row: Tuple, columns: List[Column]):
         if len(row) != len(columns):
             raise Exception(f"row {row} has not the same number of values as columns are defined")
         for i, column in enumerate(columns):

--- a/exasol_udf_mock_python/mock_context_run_wrapper.py
+++ b/exasol_udf_mock_python/mock_context_run_wrapper.py
@@ -21,12 +21,9 @@ class MockContextRunWrapper:
         else:
             self.next = self._mock_context.next
             self.reset = self._mock_context.reset
+            self.get_dataframe = self._mock_context.get_dataframe
+            self.size = self._mock_context.size
 
-    def get_dataframe(self, num_rows='all', start_col=0):
-        return self._mock_context.get_dataframe(num_rows, start_col)
 
     def __getattr__(self, name):
         return self._mock_context.__getattr__(name)
-
-    def size(self):
-        return self._mock_context.size()

--- a/exasol_udf_mock_python/udf_context.py
+++ b/exasol_udf_mock_python/udf_context.py
@@ -1,0 +1,54 @@
+from abc import ABCMeta, abstractmethod
+from typing import Union, Optional
+
+import pandas as pd
+
+
+class UDFContext(metaclass=ABCMeta):
+    """
+    UDFContext used to iterate over the input rows of the UDF and to emit output rows back to the database.
+    The columns of the input rows are accessible by their name as attributes of the UDFContext, e.g. ctx.a,
+    for the column "a".
+    """
+
+    @abstractmethod
+    def get_dataframe(self, num_rows: Union[str, int], start_col: int = 0) -> Optional[pd.DataFrame]:
+        """
+        Returns the next input rows as a pandas dataframe. This function is only available for SET UDFs.
+        :param num_rows: either the string "all", or the number of rows to return as int
+        :param start_col: determines from which column on the dataframe contains columns
+        :return: A pandas Dataframe or None, if there are now more rows
+        """
+        pass
+
+    @abstractmethod
+    def next(self, reset: bool = False) -> bool:
+        """
+        Advances the Context by one row. This function is only available for SET UDFs.
+        :param reset: Resets the context. After the reset the context stays at the first row
+        :return: True, if the Context advanced by one row, False if the Context were already at the last row
+        """
+        pass
+
+    @abstractmethod
+    def size(self) -> int:
+        """
+        Returns the number of input rows. This function is only available for SET UDFs.
+        :return:
+        """
+        pass
+
+    @abstractmethod
+    def reset(self):
+        """
+        Resets the context. After the reset the context stays at the first row. This function is only available for SET UDFs.
+        """
+        pass
+
+    @abstractmethod
+    def emit(self, *args):
+        """
+        Emits output rows to the database. This function is only available for EMITS UDFs.
+        :param args: Either, one argument per output column or a single pandas DataFrame
+        """
+        pass


### PR DESCRIPTION
- Extract interface UDFContext from MockContext
- Add documentation to UDFContext
- Fix availability of get_dataframe() and size() in the UDFContext depending on the UDF Type
- Restrict the GitHub Actions to python 3.6, because we currently only provide 3.6 in the UDFs