### PR TITLE
Split MockContext into Standalone and multi-group

### DIFF
--- a/exasol_udf_mock_python/mock_context.py
+++ b/exasol_udf_mock_python/mock_context.py
@@ -30,7 +30,7 @@ class MockContext(UDFContext):
         """ Mock context for the current group """
         self._current:Optional[StandaloneMockContext] = None
         """ Output for all groups """
-        self._previous_groups = []        # type: List[Group]
+        self._previous_groups: List[Group] = []
 
     def _next_group(self) -> bool:
         """

--- a/exasol_udf_mock_python/mock_context.py
+++ b/exasol_udf_mock_python/mock_context.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Iterator
+from typing import List, Tuple, Iterator, Any, Optional, Union
 
 import pandas as pd
 
@@ -9,49 +9,122 @@ from exasol_udf_mock_python.udf_context import UDFContext
 
 
 class MockContext(UDFContext):
+    """
+    Implementation of generic UDF Mock Context interface for a SET UDF with groups.
+    This class allows iterating over groups. The functionality of the UDF Context are applicable
+    for the current input group.
+
+    Call `_next_group` to iterate over groups. The `_output_groups` property provides the emit
+    output for all groups iterated so far including the output for the current group.
+    """
 
     def __init__(self, input_groups: Iterator[Group], metadata: MockMetaData):
+        """
+        :param input_groups:    Input groups. Each group object should contain input rows for the group.
+
+        :param metadata:        The mock metadata object.
+        """
+
         self._input_groups = input_groups
-        self._output_groups = []
-        self._input_group = None  # type: Group
-        self._output_group_list = None  # type: List
-        self._output_group = None  # type: Group
-        self._iter = None  # type: Iterator[Tuple]
-        self._len = None  # type: int
         self._metadata = metadata
+        """ Mock context for the current group """
+        self._current = None            # type: Optional[StandaloneMockContext]
+        """ Output for all groups """
+        self._previous_groups = []        # type: List[Group]
+
+    def _next_group(self) -> bool:
+        """
+        Moves group iterator to the next group.
+        Returns False if the iterator gets beyond the last group. Returns True otherwise.
+        """
+
+        # Save output of the current group
+        if self._current is not None:
+            self._previous_groups.append(Group(self._current.output))
+            self._current = None
+
+        # Try get to the next input group
+        try:
+            input_group = next(self._input_groups)
+        except StopIteration as e:
+            return False
+        if len(input_group) == 0:
+            raise RuntimeError("Empty input groups are not allowed")
+
+        # Create Mock Context for the new input group
+        self._current = StandaloneMockContext(input_group, self._metadata)
+        return True
+
+    @property
+    def _output_groups(self):
+        """
+        Output of all groups including the current one.
+        """
+        if self._current is None:
+            return self._previous_groups
+        else:
+            groups = list(self._previous_groups)
+            groups.append(Group(self._current.output))
+            return groups
+
+    def __getattr__(self, name):
+        return None if self._current is None else getattr(self._current, name)
+
+    def get_dataframe(self, num_rows: Union[str, int], start_col: int = 0) -> Optional[pd.DataFrame]:
+        return None if self._current is None else self._current.get_dataframe(num_rows, start_col)
+
+    def next(self, reset: bool = False) -> bool:
+        return False if self._current is None else self._current.next(reset)
+
+    def size(self) -> int:
+        return 0 if self._current is None else self._current.size()
+
+    def reset(self) -> None:
+        if self._current is not None:
+            self._current.reset()
+
+    def emit(self, *args):
+        if self._current is not None:
+            self._current.emit(*args)
+
+
+class StandaloneMockContext(UDFContext):
+    """
+    Implementation of generic UDF Mock Context interface a SCALAR UDF or a SET UDF with no groups.
+
+    For Emit UDFs the output in the form of the list of tuples can be
+    access by reading the `output` property.
+    """
+
+    def __init__(self, inp: Any, metadata: MockMetaData):
+        """
+        :param  inp:        Input rows for a SET UDF or parameters for a SCALAR one.
+                            In the former case the input object must be an iterable of rows. This, for example,
+                            can be a Group object. It must implement the __len__ method. Each data row must be
+                            an indexable container, e.g. a tuple. In the SCALAR case the input should also be
+                            an indexable container.
+
+        :param metadata:    The mock metadata object.
+        """
+
+        self._input = inp if metadata.input_type.upper() == 'SET' else [inp]
+        self._metadata = metadata
+        self._data = None       # type: Optional[Any]
+        self._iter = None       # type: Optional[Iterator[Tuple[Any, ...]]]
         self._name_position_map = \
             {column.name: position
              for position, column
              in enumerate(metadata.input_columns)}
+        self._output = []
+        self.next(reset=True)
 
-    def _next_group(self):
-        try:
-            self._input_group = next(self._input_groups)
-        except StopIteration as e:
-            self._data = None
-            self._output_group_list = None
-            self._output_group = None
-            self._input_group = None
-            self._iter = None
-            self._len = None
-            return False
-        self._len = len(self._input_group)
-        if self._len == 0:
-            self._data = None
-            self._output_group_list = None
-            self._output_group = None
-            self._input_group = None
-            self._iter = None
-            self._len = None
-            raise RuntimeError("Empty input groups are not allowd")
-        self._output_group_list = []
-        self._output_group = Group(self._output_group_list)
-        self._output_groups.append(self._output_group)
-        self._iter = iter(self._input_group)
-        self.next()
-        return True
+    @property
+    def output(self) -> List[Tuple[Any, ...]]:
+        """Emitted output so far"""
+        return self._output
 
-    def _is_positive_integer(self, value):
+    @staticmethod
+    def _is_positive_integer(value):
         return value is not None and isinstance(value, int) and value > 0
 
     def get_dataframe(self, num_rows='all', start_col=0):
@@ -80,10 +153,10 @@ class MockContext(UDFContext):
         return df
 
     def __getattr__(self, name):
-        return self._data[self._name_position_map[name]]
+        return None if self._data is None else self._data[self._name_position_map[name]]
 
     def next(self, reset: bool = False):
-        if reset:
+        if self._iter is None or reset:
             self.reset()
         else:
             try:
@@ -96,10 +169,10 @@ class MockContext(UDFContext):
                 return False
 
     def size(self):
-        return self._len
+        return len(self._input)
 
     def reset(self):
-        self._iter = iter(self._input_group)
+        self._iter = iter(self._input)
         self.next()
 
     def emit(self, *args):
@@ -109,10 +182,10 @@ class MockContext(UDFContext):
             tuples = [args]
         for row in tuples:
             self._validate_tuples(row, self._metadata.output_columns)
-        self._output_group_list.extend(tuples)
-        return
+        self._output.extend(tuples)
 
-    def _validate_tuples(self, row: Tuple, columns: List[Column]):
+    @staticmethod
+    def _validate_tuples(row: Tuple, columns: List[Column]):
         if len(row) != len(columns):
             raise Exception(f"row {row} has not the same number of values as columns are defined")
         for i, column in enumerate(columns):

--- a/exasol_udf_mock_python/mock_context.py
+++ b/exasol_udf_mock_python/mock_context.py
@@ -124,7 +124,7 @@ class StandaloneMockContext(UDFContext):
             self._input = inp
         self._metadata = metadata
         self._data = None       # type: Optional[Any]
-        self._iter = None       # type: Optional[Iterator[Tuple[Any, ...]]]
+        self._iter: Optional[Iterator[Tuple[Any, ...]]] = None
         self._name_position_map = \
             {column.name: position
              for position, column

--- a/exasol_udf_mock_python/mock_context.py
+++ b/exasol_udf_mock_python/mock_context.py
@@ -28,7 +28,7 @@ class MockContext(UDFContext):
         self._input_groups = input_groups
         self._metadata = metadata
         """ Mock context for the current group """
-        self._current = None            # type: Optional[StandaloneMockContext]
+        self._current:Optional[StandaloneMockContext] = None
         """ Output for all groups """
         self._previous_groups = []        # type: List[Group]
 

--- a/exasol_udf_mock_python/mock_context.py
+++ b/exasol_udf_mock_python/mock_context.py
@@ -123,7 +123,7 @@ class StandaloneMockContext(UDFContext):
         else:
             self._input = inp
         self._metadata = metadata
-        self._data = None       # type: Optional[Any]
+        self._data: Optional[Any] = None
         self._iter: Optional[Iterator[Tuple[Any, ...]]] = None
         self._name_position_map = \
             {column.name: position

--- a/exasol_udf_mock_python/udf_mock_executor.py
+++ b/exasol_udf_mock_python/udf_mock_executor.py
@@ -7,7 +7,7 @@ from exasol_udf_mock_python.mock_exa_environment import MockExaEnvironment
 
 
 def _loop_groups(ctx:MockContext, exa:MockExaEnvironment, runfunc:Callable):
-    while ctx._next_group():
+    while ctx.next_group():
         _wrapped_run(ctx, exa, runfunc)
 
 
@@ -77,4 +77,4 @@ class UDFMockExecutor:
             finally:
                 if "cleanup" in exec_globals:
                     self._exec_cleanup(exec_globals)
-            return ctx._output_groups
+            return ctx.output_groups

--- a/tests/test_mock_context.py
+++ b/tests/test_mock_context.py
@@ -1,0 +1,59 @@
+import pytest
+import pandas as pd
+
+from exasol_udf_mock_python.group import Group
+from exasol_udf_mock_python.mock_context import MockContext
+from tests.test_mock_context_standalone import meta_set_emits
+
+
+@pytest.fixture
+def context_set_emits(meta_set_emits):
+    pets = Group([(1, 'cat'), (2, 'dog')])
+    bugs = Group([(3, 'ant'), (4, 'bee'), (5, 'beetle')])
+    groups = [pets, bugs]
+    return MockContext(iter(groups), meta_set_emits)
+
+
+def test_scroll(context_set_emits):
+    assert context_set_emits._current is None
+    assert not context_set_emits._output_groups
+    assert context_set_emits._next_group()
+    assert context_set_emits.t2 == 'cat'
+    assert context_set_emits.next()
+    assert context_set_emits.t2 == 'dog'
+    assert not context_set_emits.next()
+    assert context_set_emits._next_group()
+    assert context_set_emits.t2 == 'ant'
+    assert context_set_emits.next()
+    assert context_set_emits.t2 == 'bee'
+    assert context_set_emits.next()
+    assert context_set_emits.t2 == 'beetle'
+    assert not context_set_emits.next()
+    assert not context_set_emits._next_group()
+    assert context_set_emits._current is None
+
+
+def test_output_groups(context_set_emits):
+    context_set_emits._next_group()
+    context_set_emits.emit(1, 'cat')
+    context_set_emits.emit(2, 'dog')
+    context_set_emits._next_group()
+    context_set_emits.emit(3, 'ant')
+    context_set_emits.emit(4, 'bee')
+    context_set_emits.emit(5, 'beetle')
+    context_set_emits._next_group()
+    assert len(context_set_emits._output_groups) == 2
+    assert context_set_emits._output_groups[0] == Group([(1, 'cat'), (2, 'dog')])
+    assert context_set_emits._output_groups[1] == Group([(3, 'ant'), (4, 'bee'), (5, 'beetle')])
+
+
+def test_output_groups_partial(context_set_emits):
+    context_set_emits._next_group()
+    context_set_emits.emit(1, 'cat')
+    context_set_emits.emit(2, 'dog')
+    context_set_emits._next_group()
+    context_set_emits.emit(3, 'ant')
+    context_set_emits.emit(4, 'bee')
+    assert len(context_set_emits._output_groups) == 2
+    assert context_set_emits._output_groups[0] == Group([(1, 'cat'), (2, 'dog')])
+    assert context_set_emits._output_groups[1] == Group([(3, 'ant'), (4, 'bee')])

--- a/tests/test_mock_context.py
+++ b/tests/test_mock_context.py
@@ -15,45 +15,62 @@ def context_set_emits(meta_set_emits):
 
 
 def test_scroll(context_set_emits):
-    assert context_set_emits._current is None
-    assert not context_set_emits._output_groups
-    assert context_set_emits._next_group()
+    assert not context_set_emits.output_groups
+    assert context_set_emits.next_group()
     assert context_set_emits.t2 == 'cat'
     assert context_set_emits.next()
     assert context_set_emits.t2 == 'dog'
     assert not context_set_emits.next()
-    assert context_set_emits._next_group()
+    assert context_set_emits.next_group()
     assert context_set_emits.t2 == 'ant'
     assert context_set_emits.next()
     assert context_set_emits.t2 == 'bee'
     assert context_set_emits.next()
     assert context_set_emits.t2 == 'beetle'
     assert not context_set_emits.next()
-    assert not context_set_emits._next_group()
-    assert context_set_emits._current is None
+    assert not context_set_emits.next_group()
 
 
 def test_output_groups(context_set_emits):
-    context_set_emits._next_group()
+    context_set_emits.next_group()
     context_set_emits.emit(1, 'cat')
     context_set_emits.emit(2, 'dog')
-    context_set_emits._next_group()
+    context_set_emits.next_group()
     context_set_emits.emit(3, 'ant')
     context_set_emits.emit(4, 'bee')
     context_set_emits.emit(5, 'beetle')
-    context_set_emits._next_group()
-    assert len(context_set_emits._output_groups) == 2
-    assert context_set_emits._output_groups[0] == Group([(1, 'cat'), (2, 'dog')])
-    assert context_set_emits._output_groups[1] == Group([(3, 'ant'), (4, 'bee'), (5, 'beetle')])
+    context_set_emits.next_group()
+    assert len(context_set_emits.output_groups) == 2
+    assert context_set_emits.output_groups[0] == Group([(1, 'cat'), (2, 'dog')])
+    assert context_set_emits.output_groups[1] == Group([(3, 'ant'), (4, 'bee'), (5, 'beetle')])
 
 
 def test_output_groups_partial(context_set_emits):
-    context_set_emits._next_group()
+    context_set_emits.next_group()
     context_set_emits.emit(1, 'cat')
     context_set_emits.emit(2, 'dog')
-    context_set_emits._next_group()
+    context_set_emits.next_group()
     context_set_emits.emit(3, 'ant')
     context_set_emits.emit(4, 'bee')
-    assert len(context_set_emits._output_groups) == 2
-    assert context_set_emits._output_groups[0] == Group([(1, 'cat'), (2, 'dog')])
-    assert context_set_emits._output_groups[1] == Group([(3, 'ant'), (4, 'bee')])
+    assert len(context_set_emits.output_groups) == 2
+    assert context_set_emits.output_groups[0] == Group([(1, 'cat'), (2, 'dog')])
+    assert context_set_emits.output_groups[1] == Group([(3, 'ant'), (4, 'bee')])
+
+
+def test_no_context_exception(context_set_emits):
+
+    for _ in range(3):
+        context_set_emits.next_group()
+
+    with pytest.raises(RuntimeError):
+        _ = context_set_emits.t2
+    with pytest.raises(RuntimeError):
+        _ = context_set_emits.get_dataframe()
+    with pytest.raises(RuntimeError):
+        context_set_emits.next()
+    with pytest.raises(RuntimeError):
+        _ = context_set_emits.size()
+    with pytest.raises(RuntimeError):
+        context_set_emits.reset()
+    with pytest.raises(RuntimeError):
+        context_set_emits.emit(1, 'cat')

--- a/tests/test_mock_context.py
+++ b/tests/test_mock_context.py
@@ -15,20 +15,13 @@ def context_set_emits(meta_set_emits):
 
 
 def test_scroll(context_set_emits):
-    assert not context_set_emits.output_groups
-    assert context_set_emits.next_group()
-    assert context_set_emits.t2 == 'cat'
-    assert context_set_emits.next()
-    assert context_set_emits.t2 == 'dog'
-    assert not context_set_emits.next()
-    assert context_set_emits.next_group()
-    assert context_set_emits.t2 == 'ant'
-    assert context_set_emits.next()
-    assert context_set_emits.t2 == 'bee'
-    assert context_set_emits.next()
-    assert context_set_emits.t2 == 'beetle'
-    assert not context_set_emits.next()
-    assert not context_set_emits.next_group()
+    groups = []
+    while context_set_emits.next_group():
+        group = [context_set_emits.t2]
+        while context_set_emits.next():
+            group.append(context_set_emits.t2)
+        groups.append(group)
+    assert groups == [['cat', 'dog'], ['ant', 'bee', 'beetle']]
 
 
 def test_output_groups(context_set_emits):

--- a/tests/test_mock_context_standalone.py
+++ b/tests/test_mock_context_standalone.py
@@ -1,0 +1,104 @@
+import pytest
+import pandas as pd
+
+from exasol_udf_mock_python.column import Column
+from exasol_udf_mock_python.mock_meta_data import MockMetaData
+from exasol_udf_mock_python.mock_context import StandaloneMockContext
+
+
+def udf_wrapper():
+    pass
+
+
+@pytest.fixture
+def meta_scalar_return():
+    return MockMetaData(
+        script_code_wrapper_function=udf_wrapper,
+        input_type='SCALAR',
+        input_columns=[Column('t', int, 'INTEGER')],
+        output_type='RETURNS',
+        output_columns=[Column('t', int, 'INTEGER')]
+    )
+
+
+@pytest.fixture
+def meta_set_emits():
+    return MockMetaData(
+        script_code_wrapper_function=udf_wrapper,
+        input_type='SET',
+        input_columns=[Column('t1', int, 'INTEGER'), Column('t2', str, 'VARCHAR(100)')],
+        output_type='EMITS',
+        output_columns=[Column('t1', int, 'INTEGER'), Column('t2', str, 'VARCHAR(100)')]
+    )
+
+
+@pytest.fixture
+def context_scalar_return(meta_scalar_return):
+    return StandaloneMockContext((5,), meta_scalar_return)
+
+
+@pytest.fixture
+def context_set_emits(meta_set_emits):
+    return StandaloneMockContext([(5, 'abc'), (6, 'efgh')], meta_set_emits)
+
+
+def test_get_dataframe(context_set_emits):
+    df = context_set_emits.get_dataframe()
+    expected_df = pd.DataFrame({'t1': [5, 6], 't2': ['abc', 'efgh']})
+    pd.testing.assert_frame_equal(df, expected_df)
+
+
+def test_get_dataframe_limited(context_set_emits):
+    df = context_set_emits.get_dataframe(1, 1)
+    expected_df = pd.DataFrame({'t2': ['abc']})
+    pd.testing.assert_frame_equal(df, expected_df)
+
+
+def test_attr_set(context_set_emits):
+    assert context_set_emits.t1 == 5
+    assert context_set_emits.t2 == 'abc'
+
+
+def test_attr_scalar(context_scalar_return):
+    assert context_scalar_return.t == 5
+
+
+def test_next(context_set_emits):
+    assert context_set_emits.next()
+    assert context_set_emits.t1 == 6
+    assert context_set_emits.t2 == 'efgh'
+
+
+def test_next_end(context_set_emits):
+    assert context_set_emits.next()
+    assert not context_set_emits.next()
+
+
+def test_reset(context_set_emits):
+    assert context_set_emits.next()
+    context_set_emits.reset()
+    assert context_set_emits.t1 == 5
+    assert context_set_emits.t2 == 'abc'
+
+
+def test_size(context_set_emits):
+    assert context_set_emits.size() == 2
+
+
+def test_validate_tuples_good(meta_set_emits):
+    StandaloneMockContext._validate_tuples((10, 'fish'), meta_set_emits.output_columns)
+
+
+def test_validate_tuples_bad(meta_set_emits):
+    with pytest.raises(Exception):
+        StandaloneMockContext._validate_tuples((10,), meta_set_emits.output_columns)
+    with pytest.raises(Exception):
+        StandaloneMockContext._validate_tuples((10, 'fish', 4.5), meta_set_emits.output_columns)
+    with pytest.raises(Exception):
+        StandaloneMockContext._validate_tuples((10., 'fish'), meta_set_emits.output_columns)
+
+
+def test_emit_df(context_set_emits):
+    df = pd.DataFrame({'t1': [1, 2], 't2': ['cat', 'dog']})
+    context_set_emits.emit(df)
+    assert context_set_emits.output == [(1, 'cat'), (2, 'dog')]

--- a/tests/test_mock_context_standalone.py
+++ b/tests/test_mock_context_standalone.py
@@ -70,12 +70,12 @@ def test_next(context_set_emits):
 
 
 def test_next_end(context_set_emits):
-    assert context_set_emits.next()
+    context_set_emits.next()
     assert not context_set_emits.next()
 
 
 def test_reset(context_set_emits):
-    assert context_set_emits.next()
+    context_set_emits.next()
     context_set_emits.reset()
     assert context_set_emits.t1 == 5
     assert context_set_emits.t2 == 'abc'
@@ -85,17 +85,17 @@ def test_size(context_set_emits):
     assert context_set_emits.size() == 2
 
 
-def test_validate_tuples_good(meta_set_emits):
-    StandaloneMockContext._validate_tuples((10, 'fish'), meta_set_emits.output_columns)
+def test_validate_emit_good(meta_set_emits):
+    StandaloneMockContext.validate_emit((10, 'fish'), meta_set_emits.output_columns)
 
 
-def test_validate_tuples_bad(meta_set_emits):
+def test_validate_emit_bad(meta_set_emits):
     with pytest.raises(Exception):
-        StandaloneMockContext._validate_tuples((10,), meta_set_emits.output_columns)
+        StandaloneMockContext.validate_emit((10,), meta_set_emits.output_columns)
     with pytest.raises(Exception):
-        StandaloneMockContext._validate_tuples((10, 'fish', 4.5), meta_set_emits.output_columns)
+        StandaloneMockContext.validate_emit((10, 'fish', 4.5), meta_set_emits.output_columns)
     with pytest.raises(Exception):
-        StandaloneMockContext._validate_tuples((10., 'fish'), meta_set_emits.output_columns)
+        StandaloneMockContext.validate_emit((10., 'fish'), meta_set_emits.output_columns)
 
 
 def test_emit_df(context_set_emits):

--- a/tests/test_mock_context_standalone.py
+++ b/tests/test_mock_context_standalone.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from exasol_udf_mock_python.column import Column
 from exasol_udf_mock_python.mock_meta_data import MockMetaData
-from exasol_udf_mock_python.mock_context import StandaloneMockContext
+from exasol_udf_mock_python.mock_context import StandaloneMockContext, validate_emit
 
 
 def udf_wrapper():
@@ -86,16 +86,16 @@ def test_size(context_set_emits):
 
 
 def test_validate_emit_good(meta_set_emits):
-    StandaloneMockContext.validate_emit((10, 'fish'), meta_set_emits.output_columns)
+    validate_emit((10, 'fish'), meta_set_emits.output_columns)
 
 
 def test_validate_emit_bad(meta_set_emits):
     with pytest.raises(Exception):
-        StandaloneMockContext.validate_emit((10,), meta_set_emits.output_columns)
+        validate_emit((10,), meta_set_emits.output_columns)
     with pytest.raises(Exception):
-        StandaloneMockContext.validate_emit((10, 'fish', 4.5), meta_set_emits.output_columns)
+        validate_emit((10, 'fish', 4.5), meta_set_emits.output_columns)
     with pytest.raises(Exception):
-        StandaloneMockContext.validate_emit((10., 'fish'), meta_set_emits.output_columns)
+        validate_emit((10., 'fish'), meta_set_emits.output_columns)
 
 
 def test_emit_df(context_set_emits):


### PR DESCRIPTION
Fixes #33 

Created two classes MockContext and Standalone mock context instead of one MockContext. The interface of the MockContext is preserved. The current emit output of either of the classes can be accessed through the `output` property.